### PR TITLE
Pass product name to Avalara instead of description

### DIFF
--- a/Nop.Plugin.Tax.Avalara/AvalaraTaxProvider.cs
+++ b/Nop.Plugin.Tax.Avalara/AvalaraTaxProvider.cs
@@ -312,7 +312,7 @@ namespace Nop.Plugin.Tax.Avalara
                     amount = orderItem.PriceExclTax,
 
                     //item description
-                    description = CommonHelper.EnsureMaximumLength(orderItem.Product?.ShortDescription ?? orderItem.Product?.Name, 2096),
+                    description = CommonHelper.EnsureMaximumLength(orderItem.Product.Name, 2096),
 
                     //whether the discount to the item was applied
                     discounted = order.OrderSubTotalDiscountExclTax > decimal.Zero,


### PR DESCRIPTION
We should pass the product name to Avalara as the description, not the short description.

Using short description, it looks like this in Avalara (ugly):
![image](https://user-images.githubusercontent.com/214307/71206427-23292c00-226a-11ea-82ad-36f473aba1eb.png)
